### PR TITLE
refactor: replace console logs with env-aware logger

### DIFF
--- a/lib/actions/cart/cart.actions.ts
+++ b/lib/actions/cart/cart.actions.ts
@@ -14,6 +14,7 @@ import {
   formatError,
   roundTwoDecimalPlaces,
 } from "@/lib/utils";
+import { logger } from "@/lib/logger";
 import {
   cartItemSchema,
   insertCartSchema,
@@ -122,7 +123,7 @@ export const addItemToCart = async (data: Item) => {
       }`,
     };
   } catch (error) {
-    console.log(error);
+    logger.error("Error adding item to cart", { error });
     return {
       success: false,
       message: `${GENERIC_ERROR} - ${formatError(error)}`,
@@ -154,7 +155,7 @@ export const getCartItems = async (): Promise<Cart | null> => {
       taxPrice: cart.taxPrice.toString(),
     });
   } catch (error) {
-    console.log(error);
+    logger.error("Error fetching cart items", { error });
     return null;
   }
 };

--- a/lib/actions/shipping-address/shipping-address.action.ts
+++ b/lib/actions/shipping-address/shipping-address.action.ts
@@ -1,5 +1,6 @@
 "use server";
 import { prisma } from "@/db/prisma";
+import { logger } from "@/lib/logger";
 import { shippingAddressSchema } from "@/lib/validators/shipping-address.validator";
 
 export const getShippingAddressByUserId = async (userId: string) => {
@@ -14,10 +15,13 @@ export const getShippingAddressByUserId = async (userId: string) => {
       data: address,
     };
   } catch (error) {
-    console.error("Error getting shipping address:", error);
+    logger.error("Error getting shipping address", { error });
     return {
       success: false,
-      message: "Shipping Address not found",
+      message:
+        error instanceof Error
+          ? error.message
+          : "Shipping Address not found",
     };
   }
 };
@@ -25,7 +29,7 @@ export const getShippingAddressByUserId = async (userId: string) => {
 export const saveShippingAddress = async (userId: string, address: unknown) => {
   const existingAddress = await getShippingAddressByUserId(userId);
   const shippingAddress = shippingAddressSchema.parse(address);
-  console.log(shippingAddress);
+  logger.debug("Validated shipping address", { shippingAddress });
 
   if (!shippingAddress) {
     return {
@@ -64,10 +68,13 @@ export const saveShippingAddress = async (userId: string, address: unknown) => {
       };
     }
   } catch (error) {
-    console.error("Error saving shipping address:", error);
+    logger.error("Error saving shipping address", { error });
     return {
       success: false,
-      message: "Error saving shipping address",
+      message:
+        error instanceof Error
+          ? error.message
+          : "Error saving shipping address",
     };
   }
 };

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,18 @@
+export type LogLevel = "debug" | "info" | "error";
+
+interface Meta {
+  [key: string]: unknown;
+}
+
+const log = (level: LogLevel, message: string, meta?: Meta) => {
+  if (process.env.NODE_ENV === "production") return;
+  const entry: Record<string, unknown> = { level, message };
+  if (meta) entry.meta = meta;
+  console.log(JSON.stringify(entry));
+};
+
+export const logger = {
+  debug: (message: string, meta?: Meta) => log("debug", message, meta),
+  info: (message: string, meta?: Meta) => log("info", message, meta),
+  error: (message: string, meta?: Meta) => log("error", message, meta),
+};


### PR DESCRIPTION
## Summary
- introduce minimal environment-gated JSON logger
- replace console statements in shipping and cart actions with logger and clearer errors

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfff44a87c83329706358513831200